### PR TITLE
Typo: `cwd` instead of `cmd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ scripts:
     cmd: deno run --allow-net server.ts
 ```
 
-In this case the command(s) are specified in the `cwd` property. Use the `desc` property to provide a description of what the script does, it'll be shown in the list of available scripts (when running `vr` without arguments).
+In this case the command(s) are specified in the `cmd` property. Use the `desc` property to provide a description of what the script does, it'll be shown in the list of available scripts (when running `vr` without arguments).
 
 ---
 


### PR DESCRIPTION
If I understand it correctly, the `cwd` option allows you to change the directory where the command will run, and the given block describes an option where you create the command itself.